### PR TITLE
feat(master/skip-ci): add tag to skip ci for master on release

### DIFF
--- a/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
@@ -80,7 +80,7 @@ module Fastlane
         target = options[:target]
       
         sh "git checkout #{target}"
-        sh "git merge origin/#{branch}" do |status|
+        sh "git merge origin/#{branch} -m '[skip ci]'" do |status|
           unless status.success?
             UI.error "Failed to merge #{branch} into #{target}"
           end

--- a/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
@@ -80,7 +80,7 @@ module Fastlane
         target = options[:target]
       
         sh "git checkout #{target}"
-        sh "git merge origin/#{branch} -m '[skip ci]'" do |status|
+        sh "git merge origin/#{branch} -m 'Merge #{branch} -> #{target} [skip ci]'" do |status|
           unless status.success?
             UI.error "Failed to merge #{branch} into #{target}"
           end


### PR DESCRIPTION
Adds a tag to skip CI when the master branch is pushed to during the running react-native release script.