### PR TITLE
fix(fastlane_session): avoid re-generating fastlane session unless required, add additional env var check

### DIFF
--- a/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
@@ -141,7 +141,6 @@ module Fastlane
           spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
           
           UI.message "Please enter the 6 digit 2FA code if one is sent to your device; otherwise the script will continue automatically."
-          UI.message "Please enter the 6 digit 2FA code if one is sent to your device; otherwise the script will continue automatically."
           
           `fastlane spaceauth -u #{fastlane_session_username.shellescape}`
 

--- a/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
@@ -141,8 +141,9 @@ module Fastlane
           spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
           
           UI.message "Please enter the 6 digit 2FA code if one is sent to your device; otherwise the script will continue automatically."
+          UI.message "Please enter the 6 digit 2FA code if one is sent to your device; otherwise the script will continue automatically."
           
-          `fastlane spaceauth -u #{fastlane_session_username}`
+          `fastlane spaceauth -u #{fastlane_session_username.shellescape}`
 
           other_action.cryptex(
             type: "import",

--- a/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
@@ -122,26 +122,27 @@ module Fastlane
       end
 
       # 
-      def self.create_fastlane_session()
+      def self.create_fastlane_session
         require 'fastlane/plugin/cryptex'
 
-        UI.message "Generating a new FASTLANE_SESSION."
+        UI.message "Generating a new fastlane session."
 
         fastlane_session_git_url =  ENV["FASTLANE_ENV_GIT_URL"]
         fastlane_session_username = ENV["FASTLANE_ENV_USERNAME"]
-
-        spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
-        
-        if File.exists?(spaceship_cookie_path)
-          system `rm #{spaceship_cookie_path}`
-        end
+        fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
 
         if !fastlane_session_username;
           UI.user_error!("No FASTLANE_ENV_USERNAME var at <root>/fastlane/.env\nFASTLANE_ENV_USERNAME is used to authenticate with the App Store for iOS releases.")
         elsif !fastlane_session_git_url;
           UI.user_error!("No FASTLANE_ENV_GIT_URL var at <root>/fastlane/.env\nFASTLANE_ENV_GIT_URL is used to store the App Store Connect session to upload releases on CI.")
+        elsif !fastlane_session_password;
+          UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
         else          
-          system "fastlane spaceauth -u #{fastlane_session_username}";
+          spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
+          
+          UI.message "Please enter the 6 digit 2FA code if one is sent to your device; otherwise the script will continue automatically."
+          
+          `fastlane spaceauth -u #{fastlane_session_username}`
 
           other_action.cryptex(
             type: "import",
@@ -150,7 +151,7 @@ module Fastlane
             git_url: fastlane_session_git_url
           )
 
-          UI.message "Uploaded FASTLANE_SESSION securely to git repository."
+          UI.message "Uploaded FASTLANE_SESSION variable securely to git repository."
         end
       end
 

--- a/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
@@ -130,6 +130,7 @@ module Fastlane
         fastlane_session_git_url =  ENV["FASTLANE_ENV_GIT_URL"]
         fastlane_session_username = ENV["FASTLANE_ENV_USERNAME"]
         fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
+        spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
 
         if !fastlane_session_username;
           UI.user_error!("No FASTLANE_ENV_USERNAME var at <root>/fastlane/.env\nFASTLANE_ENV_USERNAME is used to authenticate with the App Store for iOS releases.")
@@ -138,8 +139,6 @@ module Fastlane
         elsif !fastlane_session_password;
           UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
         else          
-          spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
-          
           UI.message "Please enter the 6 digit 2FA code if one is sent to your device; otherwise the script will continue automatically."
           
           `fastlane spaceauth -u #{fastlane_session_username.shellescape}`


### PR DESCRIPTION
Changes:
- Stop removing the session cookie before running `spaceauth`
- Adds additional ENV var check for `CRYPTEX_PASSWORD`