### PR TITLE
Add actions for reading and writing a fastlane session cookie outside of the release action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,24 @@ Use `agvtool` to get and set a version across your project. From the `ios` direc
 
 ### Configuring builds to TestFlight and AppStore Connect on CI
 
-To upload builds to TestFlight or AppStore Connect, your CI will need a session cookie that was generated with a 2FA code. React Native Release generates and stores this code securely in Github, when the local release script runs, and CI consumes the cookie during the IOS build upload step for jobs uploading to TestFlight or AppStore Connect.
+To upload builds to TestFlight or AppStore Connect, CI will need a cookie that was generated with a 2FA code. The `react_native_release` lane generates and stores this code securely in Github. We then use this token on CI during the IOS build upload step to TestFlight or AppStore Connect.
 
-To enable the fastlane session add an `.env` file at `<root>/fastlane/.env` with the following configuration.
+This is managed by the `fastlane-plugin-react_native_release` plugin in the iOS project. Start by adding the plugin to the iOS project by running:
+
+```bash
+cd ios && fastlane add_plugin react_native_release
+```
+
+Then add the `read_fastlane_session` command to the end of the `before_all` step in your `<root>/ios/Fastfile`:
+
+```yaml
+  before_all do
+    setup_circle_ci
+    read_fastlane_session
+  end
+```
+
+Next add an `.env` file at `<root>/fastlane/.env` with the following configuration.
 
 | KEY | TYPE | DESCRIPTION |
 |-----|------|-------------|

--- a/lib/fastlane/plugin/react_native_release/actions/create_fastlane_session_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/create_fastlane_session_action.rb
@@ -1,0 +1,63 @@
+require 'fastlane/action'
+require_relative '../helper/react_native_release_helper'
+
+module Fastlane
+  module Actions
+    class CreateFastlaneSessionAction < Action
+      def self.run(params)
+        require 'fastlane/plugin/cryptex'
+
+        UI.message "Generating a new fastlane session.."
+
+        fastlane_session_git_url =  ENV["FASTLANE_ENV_GIT_URL"]
+        fastlane_session_username = ENV["FASTLANE_ENV_USERNAME"]
+        fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
+        spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
+
+        if !fastlane_session_username
+          UI.user_error!("No FASTLANE_ENV_USERNAME var at <root>/fastlane/.env\nFASTLANE_ENV_USERNAME is used to authenticate with the App Store for iOS releases.")
+        elsif !fastlane_session_git_url
+          UI.user_error!("No FASTLANE_ENV_GIT_URL var at <root>/fastlane/.env\nFASTLANE_ENV_GIT_URL is used to store the App Store Connect session to upload releases on CI.")
+        elsif !fastlane_session_password
+          UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
+        else          
+          UI.message "Please enter the 6 digit 2FA code if one is sent to your device otherwise the script will continue automatically."
+          
+          `fastlane spaceauth -u #{fastlane_session_username.shellescape}`
+
+          other_action.cryptex(
+            type: "import",
+            in: spaceship_cookie_path,
+            key: "FASTLANE_SESSION",
+            git_url: fastlane_session_git_url
+          )
+
+          UI.message "Uploaded FASTLANE_SESSION variable securely to git repository."
+        end
+      end
+
+      def self.description
+        "Simplify 2FA authentication for App Store Connect"
+      end
+
+      def self.authors
+        ["cball", "isaiahgrey93"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        "Creates a cookie for authenticating with App Store connecting. Handles generating, encrypting, and storing the cookie."
+      end
+
+      def self.is_supported?(platform)
+        # Adjust this if your plugin only works for a particular platform (iOS vs. Android, for example)
+        # See: https://docs.fastlane.tools/advanced/#control-configuration-by-lane-and-by-platform
+        #
+        [:ios, :android].include?(platform)
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/react_native_release/actions/create_fastlane_session_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/create_fastlane_session_action.rb
@@ -7,12 +7,10 @@ module Fastlane
       def self.run(params)
         require 'fastlane/plugin/cryptex'
 
-        UI.message "Generating a new fastlane session.."
-
         fastlane_session_git_url =  ENV["FASTLANE_ENV_GIT_URL"]
         fastlane_session_username = ENV["FASTLANE_ENV_USERNAME"]
         fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
-        spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
+        fastlane_session_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
 
         if !fastlane_session_username
           UI.user_error!("No FASTLANE_ENV_USERNAME var at <root>/fastlane/.env\nFASTLANE_ENV_USERNAME is used to authenticate with the App Store for iOS releases.")
@@ -20,14 +18,16 @@ module Fastlane
           UI.user_error!("No FASTLANE_ENV_GIT_URL var at <root>/fastlane/.env\nFASTLANE_ENV_GIT_URL is used to store the App Store Connect session to upload releases on CI.")
         elsif !fastlane_session_password
           UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
-        else          
+        else
+          UI.message "Generating a new fastlane session."
+
           UI.message "Please enter the 6 digit 2FA code if one is sent to your device otherwise the script will continue automatically."
           
           `fastlane spaceauth -u #{fastlane_session_username.shellescape}`
 
           other_action.cryptex(
             type: "import",
-            in: spaceship_cookie_path,
+            in: fastlane_session_cookie_path,
             key: "FASTLANE_SESSION",
             git_url: fastlane_session_git_url
           )

--- a/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
@@ -132,14 +132,14 @@ module Fastlane
         fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
         spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
 
-        if !fastlane_session_username;
+        if !fastlane_session_username
           UI.user_error!("No FASTLANE_ENV_USERNAME var at <root>/fastlane/.env\nFASTLANE_ENV_USERNAME is used to authenticate with the App Store for iOS releases.")
-        elsif !fastlane_session_git_url;
+        elsif !fastlane_session_git_url
           UI.user_error!("No FASTLANE_ENV_GIT_URL var at <root>/fastlane/.env\nFASTLANE_ENV_GIT_URL is used to store the App Store Connect session to upload releases on CI.")
-        elsif !fastlane_session_password;
+        elsif !fastlane_session_password
           UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
         else          
-          UI.message "Please enter the 6 digit 2FA code if one is sent to your device; otherwise the script will continue automatically."
+          UI.message "Please enter the 6 digit 2FA code if one is sent to your device otherwise the script will continue automatically."
           
           `fastlane spaceauth -u #{fastlane_session_username.shellescape}`
 

--- a/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/react_native_release_action.rb
@@ -8,8 +8,8 @@ module Fastlane
 
       def self.run(params)
         require 'fastlane/plugin/android_versioning'
-        
-        create_fastlane_session
+
+        other_action.create_fastlane_session
 
         target = UI.select "Select a release type:", VALID_TARGETS
         is_beta = target.include?('beta')
@@ -121,45 +121,13 @@ module Fastlane
         UI.select("Update Version?: ", ["none", "major", "minor", "patch"])
       end
 
-      # 
-      def self.create_fastlane_session
-        require 'fastlane/plugin/cryptex'
-
-        UI.message "Generating a new fastlane session."
-
-        fastlane_session_git_url =  ENV["FASTLANE_ENV_GIT_URL"]
-        fastlane_session_username = ENV["FASTLANE_ENV_USERNAME"]
-        fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
-        spaceship_cookie_path = "#{File.expand_path('~')}/.fastlane/spaceship/#{fastlane_session_username}/cookie"
-
-        if !fastlane_session_username
-          UI.user_error!("No FASTLANE_ENV_USERNAME var at <root>/fastlane/.env\nFASTLANE_ENV_USERNAME is used to authenticate with the App Store for iOS releases.")
-        elsif !fastlane_session_git_url
-          UI.user_error!("No FASTLANE_ENV_GIT_URL var at <root>/fastlane/.env\nFASTLANE_ENV_GIT_URL is used to store the App Store Connect session to upload releases on CI.")
-        elsif !fastlane_session_password
-          UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
-        else          
-          UI.message "Please enter the 6 digit 2FA code if one is sent to your device otherwise the script will continue automatically."
-          
-          `fastlane spaceauth -u #{fastlane_session_username.shellescape}`
-
-          other_action.cryptex(
-            type: "import",
-            in: spaceship_cookie_path,
-            key: "FASTLANE_SESSION",
-            git_url: fastlane_session_git_url
-          )
-
-          UI.message "Uploaded FASTLANE_SESSION variable securely to git repository."
-        end
-      end
 
       def self.description
         "Simplify releases for React Native apps"
       end
 
       def self.authors
-        ["cball"]
+        ["cball", "isaiahgrey93"]
       end
 
       def self.return_value

--- a/lib/fastlane/plugin/react_native_release/actions/read_fastlane_session_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/read_fastlane_session_action.rb
@@ -7,8 +7,6 @@ module Fastlane
       def self.run(params)
         require 'fastlane/plugin/cryptex'
 
-        UI.message "Reading fastlane session.."
-
         fastlane_session_git_url =  ENV["FASTLANE_ENV_GIT_URL"]
         fastlane_session_username = ENV["FASTLANE_ENV_USERNAME"]
         fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
@@ -20,18 +18,20 @@ module Fastlane
         elsif !fastlane_session_password
           UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
         else
-          spaceship_cookie_file = Tempfile.new('')
+          UI.message "Reading fastlane session.."
+
+          fastlane_session_cookie_path = Tempfile.new('')
 
           other_action.cryptex(
             type: "export",
-            out: spaceship_cookie_file.path,
+            out: fastlane_session_cookie_path.path,
             key: "FASTLANE_SESSION",
             git_url: ENV["FASTLANE_ENV_GIT_URL"]
           )
 
-          fastlane_session = (open spaceship_cookie_file.path).read
+          fastlane_session = (open fastlane_session_cookie_path.path).read
 
-          UI.message spaceship_cookie_file.path
+          UI.message fastlane_session_cookie_path.path
           UI.message fastlane_session
 
           ENV["FASTLANE_SESSION"] = fastlane_session

--- a/lib/fastlane/plugin/react_native_release/actions/read_fastlane_session_action.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/read_fastlane_session_action.rb
@@ -1,0 +1,67 @@
+require 'fastlane/action'
+require_relative '../helper/react_native_release_helper'
+
+module Fastlane
+  module Actions
+    class ReadFastlaneSessionAction < Action
+      def self.run(params)
+        require 'fastlane/plugin/cryptex'
+
+        UI.message "Reading fastlane session.."
+
+        fastlane_session_git_url =  ENV["FASTLANE_ENV_GIT_URL"]
+        fastlane_session_username = ENV["FASTLANE_ENV_USERNAME"]
+        fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
+
+        if !fastlane_session_username
+          UI.user_error!("No FASTLANE_ENV_USERNAME var at <root>/fastlane/.env\nFASTLANE_ENV_USERNAME is used to authenticate with the App Store for iOS releases.")
+        elsif !fastlane_session_git_url
+          UI.user_error!("No FASTLANE_ENV_GIT_URL var at <root>/fastlane/.env\nFASTLANE_ENV_GIT_URL is used to store the App Store Connect session to upload releases on CI.")
+        elsif !fastlane_session_password
+          UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
+        else
+          spaceship_cookie_file = Tempfile.new('')
+
+          other_action.cryptex(
+            type: "export",
+            out: spaceship_cookie_file.path,
+            key: "FASTLANE_SESSION",
+            git_url: ENV["FASTLANE_ENV_GIT_URL"]
+          )
+
+          fastlane_session = (open spaceship_cookie_file.path).read
+
+          UI.message spaceship_cookie_file.path
+          UI.message fastlane_session
+
+          ENV["FASTLANE_SESSION"] = fastlane_session
+
+          UI.success "Read FASTLANE_SESSION from remote repository."
+        end
+      end
+
+      def self.description
+        "Simplify 2FA authentication for App Store Connect"
+      end
+
+      def self.authors
+        ["cball", "isaiahgrey93"]
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+      end
+
+      def self.details
+        "Fetches an encrypted cookie for authenticating with App Store connecting. Handles fetching and decrypting the cookie before setting to the local env."
+      end
+
+      def self.is_supported?(platform)
+        # Adjust this if your plugin only works for a particular platform (iOS vs. Android, for example)
+        # See: https://docs.fastlane.tools/advanced/#control-configuration-by-lane-and-by-platform
+        #
+        [:ios, :android].include?(platform)
+      end
+    end
+  end
+end


### PR DESCRIPTION
First pass at splitting out the fastlane session management into separate actions.

For generating a session, this is done inside the `release` action calling out to the `create_fastlane_session` action.

For reading this session, this is done by calling the `read_fastlane_session` action inside the `Fastfile` that where we upload iOS builds to App Store connect (see below).

To do this in the `ios` folder we need to add the `fastlane-plugin-react_native_release` plugin to the relative `Pluginfile`.

```yaml
default_platform(:ios)

platform :ios do
  before_all do
    setup_circle_ci
    read_fastlane_session # replaces the custom lane defined to sync the FASTLANE_SESSION variable to the local ENV from the remote repository.
  end
```

Resolves: #13 #9