### PR TITLE
fix: Decrypt Android Keystore path errors

### DIFF
--- a/lib/fastlane/plugin/react_native_release/actions/decrypt_android_keystore.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/decrypt_android_keystore.rb
@@ -12,16 +12,12 @@ module Fastlane
           env_file_exists = File.exists?(file)
 
           if (env_file_exists && UI.confirm("This will overwrite your existing .env file. Proceed?"))
-            other_action.cryptex(
-              type: "export",
-              out: file,
-              key: key
-            )
-
-            # There is currently a bug where the keystore needs to be in multiple paths
-            sh("cp #{file} ../android")
-          else
+            self.export_and_decrypt_keystore(file,key)
+            
+          elsif(env_file_exists)
             UI.abort_with_message!("Stepping away...")
+          else
+            self.export_and_decrypt_keystore(file,key)
           end
         # If we don't have a keystore, cryptex will throw an exception.
         rescue => ex
@@ -29,6 +25,18 @@ module Fastlane
         end
 
         UI.success("Decrypted #{key} to keystore.")
+      end
+
+      def self.export_and_decrypt_keystore(file,key)
+        other_action.cryptex(
+          type: "export",
+          out: file,
+          key: key,
+          verbose: true
+        )
+         # There is currently a bug where the keystore needs to be in multiple paths
+         # Optimized for the CI process to be running from the lane in android directory
+         sh("cp ./app/android.keystore ./")
       end
 
       # Creates a new android keystore based on the provided params. Wraps Cryptex.
@@ -112,7 +120,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ["cball", "isaiahgrey93"]
+        ["cball", "isaiahgrey93", "cmejet"]
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/react_native_release/actions/encrypt_app_vars.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/encrypt_app_vars.rb
@@ -55,7 +55,7 @@ module Fastlane
         [
           FastlaneCore::ConfigItem.new(key: :namespace,
                                        env_name: "FL_ENCRYPT_APP_VARS_NAMESPACE", # The name of the environment variable
-                                       description: "What namespace should we use? (beta, release, ENTER = root)", # a short description of this parameter
+                                       description: "What namespace should we use? (alpha, beta, release, ENTER = root)", # a short description of this parameter
                                        type: String,
                                        verify_block: lambda do |value|
                                         unless Helper::ReactNativeReleaseHelper::VALID_NAMESPACES.include?(value)
@@ -81,7 +81,7 @@ module Fastlane
 
       def self.authors
         # So no one will ever forget your contribution to fastlane :) You are awesome btw!
-        ["cball", "isaiahgrey93"]
+        ["cball", "isaiahgrey93", "cmejet"]
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/react_native_release/helper/react_native_release_helper.rb
+++ b/lib/fastlane/plugin/react_native_release/helper/react_native_release_helper.rb
@@ -10,7 +10,7 @@ module Fastlane
       APP_ENV_PATH = '.env'
       VALID_NAMESPACES = ['alpha', 'beta', 'release', ''] # empty string denotes root namespace
       ANDROID_KEYSTORE_CRYPTEX_KEY = 'ANDROID_KEYSTORE'
-      ANDROID_KEYSTORE_PATH = "android/app/android.keystore"
+      ANDROID_KEYSTORE_PATH = "../app/android.keystore"
       GOOGLE_PLAY_CREDENTIALS_CRYPTEX_KEY = 'GOOGLE_PLAY_CREDS'
       FASTLANE_SESSION_CRYPTEX_KEY = 'FASTLANE_SESSION'
 


### PR DESCRIPTION
Update decrypt keystore to optimize for CI and resolve errors in path, created issue 29 to follow-up and resolve directory/path issues for generating keystore from root directory on local machine.

Also add `alpha` namespace to the prompt when encrypting app_vars for issue #28 

![2020-02-12 11 13 08](https://user-images.githubusercontent.com/7119624/74368574-c8531300-4d88-11ea-8351-836f5ceda872.gif)
