### PR TITLE
fix(ci): updates required to build on CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ We leverage `.env` files in a number of different places.
 
 **Note: In followup releases, we will add a `react-native-release init` script to generate these for you.**
 
+### Setup CI
+
+Step 1. If you've already setup Fastlane Match, skip this section. Each provider is different, but conceptually you'll want to:
+
+- Create a machine user account on your source code provider (GitHub or BitBucket) and invite that account to both the mobile and certs repo.
+- Enable CI on the main mobile repository by pressing "Follow" or "Build"
+- In an Incognito tab, log into your CI provider with the machine user account.
+- Add a user key instead of the default deploy key. This will allow CI to auth as the machine user and gain access to _both_ the mobile repo and the context repo.
+
+Step 2. Add `CRYPTEX_GIT_URL` and `CRYPTEX_PASSWORD` to your CI environment variables.
+
 ### Configuring builds to upload to TestFlight and AppStore Connect on CI
 
 To upload builds to TestFlight or AppStore Connect, CI will need to restore a previously generated session. While possible to use an Application Specific Password to upload builds, it will not have the additional permissions required for other TestFlight / App Store operations. As such, we require generating a session.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,12 @@ Step 1. If you've already setup Fastlane Match, skip this section. Each provider
 - In an Incognito tab, log into your CI provider with the machine user account.
 - Add a user key instead of the default deploy key. This will allow CI to auth as the machine user and gain access to _both_ the mobile repo and the context repo.
 
-Step 2. Add `CRYPTEX_GIT_URL` and `CRYPTEX_PASSWORD` to your CI environment variables.
+Step 2. Add the following to your CI environment variables:
+
+- CRYPTEX_GIT_URL=(your context repo ssh git url)
+- CRYPTEX_PASSWORD=(your context repo password)
+- CRYPTEX_VERBOSE=true
+- CRYPTEX_DIGEST=sha256 (note: if you have a pre-existing setup, you should set this to md5 - see https://github.com/hjanuschka/fastlane-plugin-cryptex/pull/10)
 
 ### Configuring builds to upload to TestFlight and AppStore Connect on CI
 

--- a/lib/fastlane/plugin/react_native_release/actions/add_app_var.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/add_app_var.rb
@@ -5,13 +5,14 @@ module Fastlane
   module Actions
     class AddAppVarAction < Action
       def self.run(params)
+        is_ci = ENV[:ci].to_s === 'true'
         namespace = params[:namespace]
         key = params[:key]
         value = params[:value]
         cryptex_app_key = app_key_for(namespace)
         existing_app_vars = {}
 
-        if !UI.confirm("This will add #{key}=#{value} to the #{cryptex_app_key} namespace in the encrypted context repo. Proceed?")
+        if !is_ci && !UI.confirm("This will add #{key}=#{value} to the #{cryptex_app_key} namespace in the encrypted context repo. Proceed?")
           UI.abort_with_message!("Stepping away...")
         end
 

--- a/lib/fastlane/plugin/react_native_release/actions/add_app_var.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/add_app_var.rb
@@ -5,7 +5,7 @@ module Fastlane
   module Actions
     class AddAppVarAction < Action
       def self.run(params)
-        is_ci = ENV[:ci].to_s === 'true'
+        is_ci = ENV['CI'] === 'true'
         namespace = params[:namespace]
         key = params[:key]
         value = params[:value]

--- a/lib/fastlane/plugin/react_native_release/actions/decrypt_app_vars.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/decrypt_app_vars.rb
@@ -39,7 +39,8 @@ module Fastlane
 
         # write an env file with the merged values
         if (should_write_env)
-          open('.env', 'w') do |f|
+          # TODO: handle running action from root and from ios/android folders. This will not work properly in the root as is.
+          open('../.env', 'w') do |f|
             merged_vars.each {|key, value| f.puts "#{key}=#{value}" }
           end
 

--- a/lib/fastlane/plugin/react_native_release/actions/decrypt_app_vars.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/decrypt_app_vars.rb
@@ -5,7 +5,7 @@ module Fastlane
   module Actions
     class DecryptAppVarsAction < Action
       def self.run(params)
-        is_ci = ENV[:ci].to_s === 'true'
+        is_ci = ENV['CI'] === 'true'
         namespace = params[:namespace]
         write_env = params[:write_env]
         default_cryptex_app_key = Helper::ReactNativeReleaseHelper::APP_CRYPTEX_KEY

--- a/lib/fastlane/plugin/react_native_release/actions/decrypt_app_vars.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/decrypt_app_vars.rb
@@ -35,7 +35,7 @@ module Fastlane
 
         merged_vars = app_vars.merge(namespaced_vars)
         has_env_file = File.exists?(Helper::ReactNativeReleaseHelper::APP_ENV_PATH)
-        should_write_env = write_env && !is_ci && (!has_env_file || UI.confirm("It looks like you already have an .env file. Overwrite it?"))
+        should_write_env = write_env && (is_ci || !has_env_file || UI.confirm("It looks like you already have an .env file. Overwrite it?"))
 
         # write an env file with the merged values
         if (should_write_env)

--- a/lib/fastlane/plugin/react_native_release/actions/decrypt_app_vars.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/decrypt_app_vars.rb
@@ -5,6 +5,7 @@ module Fastlane
   module Actions
     class DecryptAppVarsAction < Action
       def self.run(params)
+        is_ci = ENV[:ci].to_s === 'true'
         namespace = params[:namespace]
         write_env = params[:write_env]
         default_cryptex_app_key = Helper::ReactNativeReleaseHelper::APP_CRYPTEX_KEY
@@ -18,7 +19,7 @@ module Fastlane
           message = "This will decrypt and merge values from #{cryptex_app_key} into #{default_cryptex_app_key}. Proceed?"
         end
 
-        if !UI.confirm(message)
+        if !is_ci && !UI.confirm(message)
           UI.abort_with_message!("Stepping away...")
         end
 
@@ -34,7 +35,7 @@ module Fastlane
 
         merged_vars = app_vars.merge(namespaced_vars)
         has_env_file = File.exists?(Helper::ReactNativeReleaseHelper::APP_ENV_PATH)
-        should_write_env = write_env && (!has_env_file || UI.confirm("It looks like you already have an .env file. Overwrite it?"))
+        should_write_env = write_env && !is_ci && (!has_env_file || UI.confirm("It looks like you already have an .env file. Overwrite it?"))
 
         # write an env file with the merged values
         if (should_write_env)

--- a/lib/fastlane/plugin/react_native_release/actions/read_fastlane_session.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/read_fastlane_session.rb
@@ -5,7 +5,6 @@ module Fastlane
   module Actions
     class ReadFastlaneSessionAction < Action
       def self.run(params)
-        username = params[:username]
         key = Helper::ReactNativeReleaseHelper::FASTLANE_SESSION_CRYPTEX_KEY
         fastlane_session_git_url =  ENV["CRYPTEX_GIT_URL"]
         fastlane_session_password = ENV["CRYPTEX_PASSWORD"]

--- a/lib/fastlane/plugin/react_native_release/actions/read_fastlane_session.rb
+++ b/lib/fastlane/plugin/react_native_release/actions/read_fastlane_session.rb
@@ -1,43 +1,32 @@
 require 'fastlane/action'
-require_relative '../helper/react_native_release_helper'
+require 'fastlane/plugin/cryptex'
 
 module Fastlane
   module Actions
     class ReadFastlaneSessionAction < Action
       def self.run(params)
-        require 'fastlane/plugin/cryptex'
-
-        fastlane_session_git_url =  ENV["FASTLANE_ENV_GIT_URL"]
-        fastlane_session_username = ENV["FASTLANE_ENV_USERNAME"]
+        username = params[:username]
+        key = Helper::ReactNativeReleaseHelper::FASTLANE_SESSION_CRYPTEX_KEY
+        fastlane_session_git_url =  ENV["CRYPTEX_GIT_URL"]
         fastlane_session_password = ENV["CRYPTEX_PASSWORD"]
+        fastlane_session_cookie_path = Tempfile.new('')
 
-        if !fastlane_session_username
-          UI.user_error!("No FASTLANE_ENV_USERNAME var at <root>/fastlane/.env\nFASTLANE_ENV_USERNAME is used to authenticate with the App Store for iOS releases.")
-        elsif !fastlane_session_git_url
-          UI.user_error!("No FASTLANE_ENV_GIT_URL var at <root>/fastlane/.env\nFASTLANE_ENV_GIT_URL is used to store the App Store Connect session to upload releases on CI.")
-        elsif !fastlane_session_password
-          UI.user_error!("No CRYPTEX_PASSWORD var at <root>/fastlane/.env\nCRYPTEX_PASSWORD is used to encrypt/decrypt the App Store Connect session.")
-        else
-          UI.message "Reading fastlane session.."
+        UI.message "Reading fastlane session.."
 
-          fastlane_session_cookie_path = Tempfile.new('')
+        other_action.cryptex(
+          type: "export",
+          out: fastlane_session_cookie_path.path,
+          key: key,
+        )
 
-          other_action.cryptex(
-            type: "export",
-            out: fastlane_session_cookie_path.path,
-            key: "FASTLANE_SESSION",
-            git_url: ENV["FASTLANE_ENV_GIT_URL"]
-          )
+        fastlane_session = (open fastlane_session_cookie_path.path).read
 
-          fastlane_session = (open fastlane_session_cookie_path.path).read
+        UI.message fastlane_session_cookie_path.path
+        UI.message fastlane_session
 
-          UI.message fastlane_session_cookie_path.path
-          UI.message fastlane_session
+        ENV["FASTLANE_SESSION"] = fastlane_session
 
-          ENV["FASTLANE_SESSION"] = fastlane_session
-
-          UI.success "Read FASTLANE_SESSION from remote repository."
-        end
+        UI.success "Read FASTLANE_SESSION from remote repository."
       end
 
       def self.description


### PR DESCRIPTION
This smooths out the edges from the last PR and contains everything required to build on Circle. Also adds a few starter docs for a CI section of the README. We'll revisit this after we get more of the pieces together.

- Don't ever prompt for user input
- Update `read_fastlane_session` to reuse already defined ENV vars
- Add initial Setup CI docs
- Write .env if on CI
- Update .env paths