### PR TITLE
chore: bump version for release

### DIFF
--- a/lib/fastlane/plugin/react_native_release/version.rb
+++ b/lib/fastlane/plugin/react_native_release/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module ReactNativeRelease
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end


### PR DESCRIPTION
Bump version from `0.6.0` to `0.7.0`